### PR TITLE
Remove channels parameter which limits payment channels shown

### DIFF
--- a/projects/angular4-paystack/src/lib/angular4-paystack-embed.component.ts
+++ b/projects/angular4-paystack/src/lib/angular4-paystack-embed.component.ts
@@ -65,7 +65,6 @@ export class Angular4PaystackEmbed implements OnInit {
       plan: this.plan || '',
       quantity: this.quantity || '',
       subaccount: this.subaccount || '',
-      channels: this.channels || ['card', 'bank'],
       transaction_charge: this.transaction_charge || 0,
       bearer: this.bearer || '',
       callback: (res) => this.callback.emit(res),

--- a/projects/angular4-paystack/src/lib/angular4-paystack.component.ts
+++ b/projects/angular4-paystack/src/lib/angular4-paystack.component.ts
@@ -69,7 +69,6 @@ export class Angular4PaystackComponent implements OnInit, OnChanges {
       metadata: this.metadata || {},
       currency: this.currency || 'NGN' ,
       plan: this.plan || '' ,
-      channels: this.channels || ['card', 'bank'],
       quantity: this.quantity || '' ,
       subaccount: this.subaccount || '' ,
       transaction_charge: this.transaction_charge || 0 ,

--- a/projects/angular4-paystack/src/lib/angular4-paystack.directive.ts
+++ b/projects/angular4-paystack/src/lib/angular4-paystack.directive.ts
@@ -66,7 +66,6 @@ export class Angular4PaystackDirective {
       plan: this.plan || '' ,
       quantity: this.quantity || '' ,
       subaccount: this.subaccount || '' ,
-      channels: this.channels || ['card', 'bank'],
       transaction_charge: this.transaction_charge || 0 ,
       bearer: this.bearer || '' ,
       callback: (res) => {


### PR DESCRIPTION
Passing the parameter

`
channels: ["card", "bank"]
` 
is limiting the payment channels on checkout and not showing the USSD, and Visa QR options.

Removing this parameter allows merchants to have all channels by default. They can still pass in channels of choice if they need to restrict.