### PR TITLE
changed (close) events to (onClose).

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 ## USAGE
 
 ### 1. Install the module
+
 ```sh
 npm install --save angular4-paystack
 ```
 
 ### 2. Import the module
+
 In your `app.module.ts` or any module where the component or directive would be used like so:
 
 ```ts
@@ -28,118 +30,126 @@ export class AppModule {}
 ```
 
 ### 3. Implement in your project
+
 There are two available options
 
-* **AngularPaystackComponent**: Renders a button which when clicked loads paystack Inline in an iframe
-  ```html
-    <angular4-paystack
-      [email]="'mailexample@mail.com'"
-      [amount]="5000000"
-      [ref]="reference"
-      [channels]="['bank']"
-      [class]="'btn btn-primary'"
-      (close)="paymentCancel()"
-      (callback)="paymentDone($event)"
-    >
-      Pay with Paystack
-    </angular4-paystack>
-  ```
+- **AngularPaystackComponent**: Renders a button which when clicked loads paystack Inline in an iframe
 
-*  **AngularPaystackDirective**: A directive that loads paystack inline in an iframe when clicked
-```html
-  <button
-    angular4-paystack
-    [key]="'pk_test_xxxxxxxxxxxxxxxxxxxxxxx'"
+  ```html
+  <angular4-paystack
     [email]="'mailexample@mail.com'"
     [amount]="5000000"
     [ref]="reference"
+    [channels]="['bank']"
     [class]="'btn btn-primary'"
-    (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
+    (onClose)="paymentCancel()"
     (callback)="paymentDone($event)"
   >
     Pay with Paystack
-  </button>
-```
+  </angular4-paystack>
+  ```
 
-And then in your `component.ts`
-```ts
-  import { Component, OnInit } from '@angular/core';
+- **AngularPaystackDirective**: A directive that loads paystack inline in an iframe when clicked
 
-  @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.css']
-  })
-  export class AppComponent implements OnInit {
-    reference = '';
-    constructor() {}
-
-    paymentInit() {
-      console.log('Payment initialized');
-    }
-
-    paymentDone(ref: any) {
-      this.title = 'Payment successfull';
-      console.log(this.title, ref);
-    }
-
-    paymentCancel() {
-      console.log('payment failed');
-    }
-
-    ngOnInit() {
-      this.reference = `ref-${Math.ceil(Math.random() * 10e13)}`;
-    }
-
-  }
-```
-Also you can use the `paystackOptions` object like so:
 ```html
-  <button
-    angular4-paystack
-    [paystackOptions]="options"
-    (paymentInit)="paymentCancel()"
-    (close)="paymentCancel()"
-    (callback)="paymentDone($event)"
-  >
-    Pay with Paystack
-  </button>
+<button
+  angular4-paystack
+  [key]="'pk_test_xxxxxxxxxxxxxxxxxxxxxxx'"
+  [email]="'mailexample@mail.com'"
+  [amount]="5000000"
+  [ref]="reference"
+  [class]="'btn btn-primary'"
+  (paymentInit)="paymentInit()"
+  (onClose)="paymentCancel()"
+  (callback)="paymentDone($event)"
+>
+  Pay with Paystack
+</button>
 ```
 
 And then in your `component.ts`
+
 ```ts
-  import { Component } from '@angular/core';
-  import { PaystackOptions } from 'angular4-paystack';
+import { Component, OnInit } from "@angular/core";
 
-  @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.css']
-  })
-  export class AppComponent {
-    options: PaystackOptions = {
-      amount: 50000,
-      email: 'user@mail.com',
-      ref: `${Math.ceil(Math.random() * 10e10)}`
-    }
-    constructor() {}
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
+})
+export class AppComponent implements OnInit {
+  reference = "";
+  constructor() {}
 
-    paymentInit() {
-      console.log('Payment initialized');
-    }
-
-    paymentDone(ref: any) {
-      this.title = 'Payment successfull';
-      console.log(this.title, ref);
-    }
-
-    paymentCancel() {
-      console.log('payment failed');
-    }
+  paymentInit() {
+    console.log("Payment initialized");
   }
+
+  paymentDone(ref: any) {
+    this.title = "Payment successfull";
+    console.log(this.title, ref);
+  }
+
+  paymentCancel() {
+    console.log("payment failed");
+  }
+
+  ngOnInit() {
+    this.reference = `ref-${Math.ceil(Math.random() * 10e13)}`;
+  }
+}
 ```
+
+Also you can use the `paystackOptions` object like so:
+
+```html
+<button
+  angular4-paystack
+  [paystackOptions]="options"
+  (paymentInit)="paymentCancel()"
+  (onClose)="paymentCancel()"
+  (callback)="paymentDone($event)"
+>
+  Pay with Paystack
+</button>
+```
+
+And then in your `component.ts`
+
+```ts
+import { Component } from "@angular/core";
+import { PaystackOptions } from "angular4-paystack";
+
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
+})
+export class AppComponent {
+  options: PaystackOptions = {
+    amount: 50000,
+    email: "user@mail.com",
+    ref: `${Math.ceil(Math.random() * 10e10)}`,
+  };
+  constructor() {}
+
+  paymentInit() {
+    console.log("Payment initialized");
+  }
+
+  paymentDone(ref: any) {
+    this.title = "Payment successfull";
+    console.log(this.title, ref);
+  }
+
+  paymentCancel() {
+    console.log("payment failed");
+  }
+}
+```
+
 Also, you can pass in a key in the component and the directive, in such situation, this key is given a higher preference over the global `forRoot` key. For example, if you have this is your file
+
 ```ts
 @NgModule({
   imports: [
@@ -147,56 +157,57 @@ Also, you can pass in a key in the component and the directive, in such situatio
   ]
 })
 ```
-and this in your component
-```html
-  <button
-    angular4-paystack
-    [key]="'pk_test_2'"
-    [email]="'mailexample@mail.com'"
-    [amount]="5000000"
-    [ref]="reference"
-    [class]="'btn btn-primary'"
-    (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
-    (callback)="paymentDone($event)"
-  >
-    Pay with Paystack
-  </button>
-```
-Then `pk_test_2` would be used instead
 
+and this in your component
+
+```html
+<button
+  angular4-paystack
+  [key]="'pk_test_2'"
+  [email]="'mailexample@mail.com'"
+  [amount]="5000000"
+  [ref]="reference"
+  [class]="'btn btn-primary'"
+  (paymentInit)="paymentInit()"
+  (onClose)="paymentCancel()"
+  (callback)="paymentDone($event)"
+>
+  Pay with Paystack
+</button>
+```
+
+Then `pk_test_2` would be used instead
 
 ## OPTIONS
 
-|Name                   | Type           | Required            | Default Value       | Description         |
-|-----------------------|----------------|---------------------|---------------------|---------------------|
-|  `amount `            | `number`       | true                |  undefined          | Amount to withdraw (in kobo for NGN)
-|  `email `             | `string`       | true                |  undefined          | The customer's email address.
-|  `key`                | `string`       | true                |  undefined          | Your pubic Key from Paystack. Use test key for test mode and live key for live mode
-|  `ref`                | `string`       | true                |  undefined          | Unique case sensitive transaction reference. Only -,., = and alphanumeric characters allowed.
-|  `callback`           | `function`     | true                |  undefined          | A function called when transaction is successful. Returns an object containing unique reference
-|  `metadata`           | `object`       | false               |  {}                 | custom details
-|  `class`              | `string`       | false               |  undefined          | A string of classes to add to the component (not available for **inline embed**)
-|  `style`              | `object`       | false               |  undefined          | CSS stylings, eg ```{fontColor: 'red'}```  (not available for **inline embed**)
-|  `text`               | `object`       | false               |  undefined          | Text output of the component
-|  `currency`           | `string`       | false               |  "NGN"              | Transaction currency
-|  `plan`               | `string`       | false               |  ""                 | If transaction is to create a subscription to a predefined plan, provide plan code here.
-|  `quantity`           | `string`       | false               |  ""                 | Used to apply a multiple to the amount returned by the plan code above.
-|  `paystackOptions`     | `object`     | false               |  undefined          | An object containing the paystack options above. **NOTE:** The function listeners eg `callback`, `paymentInit` should not be added here
-|  `paymentInit`        | `function`     | false               |  undefined          | A function called when the payment is about to begin
-|  `onClose`            | `function`     | false               |  undefined          | A function called if the customer closes the payment window
-**For Split Payments** |
-|  `subaccount`         | `string`       | false               |  ""                 | The code for the subaccount that owns the payment.
-|  `transaction_charge` | `number`       | false               |  0                  |  A flat fee to charge the subaccount for this transaction, in kobo.
-|  `bearer`             | `string`       | false               |  ""                 | Who bears Paystack charges? account or subaccount
-|  `channels`           | `array`         | false              | undefined  | Send 'card' or 'bank' or 'card','bank' as an array to specify what options to show the user paying
+| Name                   | Type       | Required | Default Value | Description                                                                                                                             |
+| ---------------------- | ---------- | -------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `amount`               | `number`   | true     | undefined     | Amount to withdraw (in kobo for NGN)                                                                                                    |
+| `email`                | `string`   | true     | undefined     | The customer's email address.                                                                                                           |
+| `key`                  | `string`   | true     | undefined     | Your pubic Key from Paystack. Use test key for test mode and live key for live mode                                                     |
+| `ref`                  | `string`   | true     | undefined     | Unique case sensitive transaction reference. Only -,., = and alphanumeric characters allowed.                                           |
+| `callback`             | `function` | true     | undefined     | A function called when transaction is successful. Returns an object containing unique reference                                         |
+| `metadata`             | `object`   | false    | {}            | custom details                                                                                                                          |
+| `class`                | `string`   | false    | undefined     | A string of classes to add to the component (not available for **inline embed**)                                                        |
+| `style`                | `object`   | false    | undefined     | CSS stylings, eg `{fontColor: 'red'}` (not available for **inline embed**)                                                              |
+| `text`                 | `object`   | false    | undefined     | Text output of the component                                                                                                            |
+| `currency`             | `string`   | false    | "NGN"         | Transaction currency                                                                                                                    |
+| `plan`                 | `string`   | false    | ""            | If transaction is to create a subscription to a predefined plan, provide plan code here.                                                |
+| `quantity`             | `string`   | false    | ""            | Used to apply a multiple to the amount returned by the plan code above.                                                                 |
+| `paystackOptions`      | `object`   | false    | undefined     | An object containing the paystack options above. **NOTE:** The function listeners eg `callback`, `paymentInit` should not be added here |
+| `paymentInit`          | `function` | false    | undefined     | A function called when the payment is about to begin                                                                                    |
+| `onClose`              | `function` | false    | undefined     | A function called if the customer closes the payment window                                                                             |
+| **For Split Payments** |
+| `subaccount`           | `string`   | false    | ""            | The code for the subaccount that owns the payment.                                                                                      |
+| `transaction_charge`   | `number`   | false    | 0             | A flat fee to charge the subaccount for this transaction, in kobo.                                                                      |
+| `bearer`               | `string`   | false    | ""            | Who bears Paystack charges? account or subaccount                                                                                       |
+| `channels`             | `array`    | false    | undefined     | Send 'card' or 'bank' or 'card','bank' as an array to specify what options to show the user paying                                      |
 
 > For more information checkout [paystack's documentation](https://developers.paystack.co/docs/paystack-inline#section-working-with-paystack-inline)
 
 ## Contributing
 
 Please feel free to fork this package and contribute by submitting a pull request to enhance the functionalities.
-
 
 ## How can I thank you?
 

--- a/projects/angular4-paystack/README.md
+++ b/projects/angular4-paystack/README.md
@@ -5,11 +5,13 @@
 ## USAGE
 
 ### 1. Install the module
+
 ```sh
 npm install --save angular4-paystack
 ```
 
 ### 2. Import the module
+
 In your `app.module.ts` or any module where the component or directive would be used like so:
 
 ```ts
@@ -28,118 +30,126 @@ export class AppModule {}
 ```
 
 ### 3. Implement in your project
+
 There are two available options
 
-* **AngularPaystackComponent**: Renders a button which when clicked loads paystack Inline in an iframe
-  ```html
-    <angular4-paystack
-      [email]="'mailexample@mail.com'"
-      [amount]="5000000"
-      [ref]="reference"
-      [channels]="['bank']"
-      [class]="'btn btn-primary'"
-      (close)="paymentCancel()"
-      (callback)="paymentDone($event)"
-    >
-      Pay with Paystack
-    </angular4-paystack>
-  ```
+- **AngularPaystackComponent**: Renders a button which when clicked loads paystack Inline in an iframe
 
-*  **AngularPaystackDirective**: A directive that loads paystack inline in an iframe when clicked
-```html
-  <button
-    angular4-paystack
-    [key]="'pk_test_xxxxxxxxxxxxxxxxxxxxxxx'"
+  ```html
+  <angular4-paystack
     [email]="'mailexample@mail.com'"
     [amount]="5000000"
     [ref]="reference"
+    [channels]="['bank']"
     [class]="'btn btn-primary'"
-    (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
+    (onClose)="paymentCancel()"
     (callback)="paymentDone($event)"
   >
     Pay with Paystack
-  </button>
-```
+  </angular4-paystack>
+  ```
 
-And then in your `component.ts`
-```ts
-  import { Component, OnInit } from '@angular/core';
+- **AngularPaystackDirective**: A directive that loads paystack inline in an iframe when clicked
 
-  @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.css']
-  })
-  export class AppComponent implements OnInit {
-    reference = '';
-    constructor() {}
-
-    paymentInit() {
-      console.log('Payment initialized');
-    }
-
-    paymentDone(ref: any) {
-      this.title = 'Payment successfull';
-      console.log(this.title, ref);
-    }
-
-    paymentCancel() {
-      console.log('payment failed');
-    }
-
-    ngOnInit() {
-      this.reference = `ref-${Math.ceil(Math.random() * 10e13)}`;
-    }
-
-  }
-```
-Also you can use the `paystackOptions` object like so:
 ```html
-  <button
-    angular4-paystack
-    [paystackOptions]="options"
-    (paymentInit)="paymentCancel()"
-    (close)="paymentCancel()"
-    (callback)="paymentDone($event)"
-  >
-    Pay with Paystack
-  </button>
+<button
+  angular4-paystack
+  [key]="'pk_test_xxxxxxxxxxxxxxxxxxxxxxx'"
+  [email]="'mailexample@mail.com'"
+  [amount]="5000000"
+  [ref]="reference"
+  [class]="'btn btn-primary'"
+  (paymentInit)="paymentInit()"
+  (onClose)="paymentCancel()"
+  (callback)="paymentDone($event)"
+>
+  Pay with Paystack
+</button>
 ```
 
 And then in your `component.ts`
+
 ```ts
-  import { Component } from '@angular/core';
-  import { PaystackOptions } from 'angular4-paystack';
+import { Component, OnInit } from "@angular/core";
 
-  @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.css']
-  })
-  export class AppComponent {
-    options: PaystackOptions = {
-      amount: 50000,
-      email: 'user@mail.com',
-      ref: `${Math.ceil(Math.random() * 10e10)}`
-    }
-    constructor() {}
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
+})
+export class AppComponent implements OnInit {
+  reference = "";
+  constructor() {}
 
-    paymentInit() {
-      console.log('Payment initialized');
-    }
-
-    paymentDone(ref: any) {
-      this.title = 'Payment successfull';
-      console.log(this.title, ref);
-    }
-
-    paymentCancel() {
-      console.log('payment failed');
-    }
+  paymentInit() {
+    console.log("Payment initialized");
   }
+
+  paymentDone(ref: any) {
+    this.title = "Payment successfull";
+    console.log(this.title, ref);
+  }
+
+  paymentCancel() {
+    console.log("payment failed");
+  }
+
+  ngOnInit() {
+    this.reference = `ref-${Math.ceil(Math.random() * 10e13)}`;
+  }
+}
 ```
+
+Also you can use the `paystackOptions` object like so:
+
+```html
+<button
+  angular4-paystack
+  [paystackOptions]="options"
+  (paymentInit)="paymentCancel()"
+  (onClose)="paymentCancel()"
+  (callback)="paymentDone($event)"
+>
+  Pay with Paystack
+</button>
+```
+
+And then in your `component.ts`
+
+```ts
+import { Component } from "@angular/core";
+import { PaystackOptions } from "angular4-paystack";
+
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
+})
+export class AppComponent {
+  options: PaystackOptions = {
+    amount: 50000,
+    email: "user@mail.com",
+    ref: `${Math.ceil(Math.random() * 10e10)}`,
+  };
+  constructor() {}
+
+  paymentInit() {
+    console.log("Payment initialized");
+  }
+
+  paymentDone(ref: any) {
+    this.title = "Payment successfull";
+    console.log(this.title, ref);
+  }
+
+  paymentCancel() {
+    console.log("payment failed");
+  }
+}
+```
+
 Also, you can pass in a key in the component and the directive, in such situation, this key is given a higher preference over the global `forRoot` key. For example, if you have this is your file
+
 ```ts
 @NgModule({
   imports: [
@@ -147,56 +157,57 @@ Also, you can pass in a key in the component and the directive, in such situatio
   ]
 })
 ```
-and this in your component
-```html
-  <button
-    angular4-paystack
-    [key]="'pk_test_2'"
-    [email]="'mailexample@mail.com'"
-    [amount]="5000000"
-    [ref]="reference"
-    [class]="'btn btn-primary'"
-    (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
-    (callback)="paymentDone($event)"
-  >
-    Pay with Paystack
-  </button>
-```
-Then `pk_test_2` would be used instead
 
+and this in your component
+
+```html
+<button
+  angular4-paystack
+  [key]="'pk_test_2'"
+  [email]="'mailexample@mail.com'"
+  [amount]="5000000"
+  [ref]="reference"
+  [class]="'btn btn-primary'"
+  (paymentInit)="paymentInit()"
+  (onClose)="paymentCancel()"
+  (callback)="paymentDone($event)"
+>
+  Pay with Paystack
+</button>
+```
+
+Then `pk_test_2` would be used instead
 
 ## OPTIONS
 
-|Name                   | Type           | Required            | Default Value       | Description         |
-|-----------------------|----------------|---------------------|---------------------|---------------------|
-|  `amount `            | `number`       | true                |  undefined          | Amount to withdraw (in kobo for NGN)
-|  `email `             | `string`       | true                |  undefined          | The customer's email address.
-|  `key`                | `string`       | true                |  undefined          | Your pubic Key from Paystack. Use test key for test mode and live key for live mode
-|  `ref`                | `string`       | true                |  undefined          | Unique case sensitive transaction reference. Only -,., = and alphanumeric characters allowed.
-|  `callback`           | `function`     | true                |  undefined          | A function called when transaction is successful. Returns an object containing unique reference
-|  `metadata`           | `object`       | false               |  {}                 | custom details
-|  `class`              | `string`       | false               |  undefined          | A string of classes to add to the component (not available for **inline embed**)
-|  `style`              | `object`       | false               |  undefined          | CSS stylings, eg ```{fontColor: 'red'}```  (not available for **inline embed**)
-|  `text`               | `object`       | false               |  undefined          | Text output of the component
-|  `currency`           | `string`       | false               |  "NGN"              | Transaction currency
-|  `plan`               | `string`       | false               |  ""                 | If transaction is to create a subscription to a predefined plan, provide plan code here.
-|  `quantity`           | `string`       | false               |  ""                 | Used to apply a multiple to the amount returned by the plan code above.
-|  `paystackOptions`     | `object`     | false               |  undefined          | An object containing the paystack options above. **NOTE:** The function listeners eg `callback`, `paymentInit` should not be added here
-|  `paymentInit`        | `function`     | false               |  undefined          | A function called when the payment is about to begin
-|  `onClose`            | `function`     | false               |  undefined          | A function called if the customer closes the payment window
-**For Split Payments** |
-|  `subaccount`         | `string`       | false               |  ""                 | The code for the subaccount that owns the payment.
-|  `transaction_charge` | `number`       | false               |  0                  |  A flat fee to charge the subaccount for this transaction, in kobo.
-|  `bearer`             | `string`       | false               |  ""                 | Who bears Paystack charges? account or subaccount
-|  `channels`           | `array`         | false              | undefined  | Send 'card' or 'bank' or 'card','bank' as an array to specify what options to show the user paying
+| Name                   | Type       | Required | Default Value | Description                                                                                                                             |
+| ---------------------- | ---------- | -------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `amount`               | `number`   | true     | undefined     | Amount to withdraw (in kobo for NGN)                                                                                                    |
+| `email`                | `string`   | true     | undefined     | The customer's email address.                                                                                                           |
+| `key`                  | `string`   | true     | undefined     | Your pubic Key from Paystack. Use test key for test mode and live key for live mode                                                     |
+| `ref`                  | `string`   | true     | undefined     | Unique case sensitive transaction reference. Only -,., = and alphanumeric characters allowed.                                           |
+| `callback`             | `function` | true     | undefined     | A function called when transaction is successful. Returns an object containing unique reference                                         |
+| `metadata`             | `object`   | false    | {}            | custom details                                                                                                                          |
+| `class`                | `string`   | false    | undefined     | A string of classes to add to the component (not available for **inline embed**)                                                        |
+| `style`                | `object`   | false    | undefined     | CSS stylings, eg `{fontColor: 'red'}` (not available for **inline embed**)                                                              |
+| `text`                 | `object`   | false    | undefined     | Text output of the component                                                                                                            |
+| `currency`             | `string`   | false    | "NGN"         | Transaction currency                                                                                                                    |
+| `plan`                 | `string`   | false    | ""            | If transaction is to create a subscription to a predefined plan, provide plan code here.                                                |
+| `quantity`             | `string`   | false    | ""            | Used to apply a multiple to the amount returned by the plan code above.                                                                 |
+| `paystackOptions`      | `object`   | false    | undefined     | An object containing the paystack options above. **NOTE:** The function listeners eg `callback`, `paymentInit` should not be added here |
+| `paymentInit`          | `function` | false    | undefined     | A function called when the payment is about to begin                                                                                    |
+| `onClose`              | `function` | false    | undefined     | A function called if the customer closes the payment window                                                                             |
+| **For Split Payments** |
+| `subaccount`           | `string`   | false    | ""            | The code for the subaccount that owns the payment.                                                                                      |
+| `transaction_charge`   | `number`   | false    | 0             | A flat fee to charge the subaccount for this transaction, in kobo.                                                                      |
+| `bearer`               | `string`   | false    | ""            | Who bears Paystack charges? account or subaccount                                                                                       |
+| `channels`             | `array`    | false    | undefined     | Send 'card' or 'bank' or 'card','bank' as an array to specify what options to show the user paying                                      |
 
 > For more information checkout [paystack's documentation](https://developers.paystack.co/docs/paystack-inline#section-working-with-paystack-inline)
 
 ## Contributing
 
 Please feel free to fork this package and contribute by submitting a pull request to enhance the functionalities.
-
 
 ## How can I thank you?
 

--- a/projects/angular4-paystack/src/lib/angular4-paystack.directive.spec.ts
+++ b/projects/angular4-paystack/src/lib/angular4-paystack.directive.spec.ts
@@ -1,13 +1,14 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, DebugElement } from '@angular/core';
-import { By } from '@angular/platform-browser';
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { Component, DebugElement } from "@angular/core";
+import { By } from "@angular/platform-browser";
 
-import { Angular4PaystackDirective } from './angular4-paystack.directive';
-import { Angular4PaystackService } from './angular4-paystack.service';
-import { PUBLIC_KEY_TOKEN } from './paystack-token';
+import { Angular4PaystackDirective } from "./angular4-paystack.directive";
+import { Angular4PaystackService } from "./angular4-paystack.service";
+import { PUBLIC_KEY_TOKEN } from "./paystack-token";
 
 @Component({
-  template: `<button type="text"
+  template: `<button
+    type="text"
     class="btn btn-danger m-3"
     angular4-paystack
     [channels]="['card', 'bank']"
@@ -15,52 +16,50 @@ import { PUBLIC_KEY_TOKEN } from './paystack-token';
     [amount]="'5000000'"
     [ref]="'some-random-str'"
     (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
+    (onClose)="paymentCancel()"
     (callback)="paymentDone($event)"
     [class]="'btn btn-primary btn-lg'"
   >
     Pay
-  </button>
-  `
+  </button> `,
 })
 class TestComponent {
   paymentInit() {
-    return 'initialized';
+    return "initialized";
   }
 
   paymentDone(ref: any) {
-   return 'successful';
+    return "successful";
   }
 
   paymentCancel() {
-    return 'failed';
+    return "failed";
   }
 }
 
-describe('Angular4PaystackDirective', () => {
+describe("Angular4PaystackDirective", () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
   let payButton: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ Angular4PaystackDirective, TestComponent ],
+      declarations: [Angular4PaystackDirective, TestComponent],
       providers: [
         Angular4PaystackService,
-        { provide: PUBLIC_KEY_TOKEN, useValue: 'public-key' }
-      ]
-    })
-    .compileComponents();
+        { provide: PUBLIC_KEY_TOKEN, useValue: "public-key" },
+      ],
+    }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    payButton = fixture.debugElement.query(By.css('button'));
+    payButton = fixture.debugElement.query(By.css("button"));
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,13 +1,18 @@
-<div class="display-4 py-4 px-1 text-center bg-primary text-white">Angular4 Paystack</div>
+<div class="display-4 py-4 px-1 text-center bg-primary text-white">
+  Angular4 Paystack
+</div>
 <div class="text-center lead">{{ title }}</div>
 <div class="container">
-  <div class="paystack-buttons text-center d-md-flex d-lg-flex d-xl-flex justify-content-between">
+  <div
+    class="paystack-buttons text-center d-md-flex d-lg-flex d-xl-flex justify-content-between"
+  >
     <angular4-paystack
       [class]="'btn btn-primary m-3'"
       [email]="'mailexample@mail.com'"
       (paymentInit)="paymentInit()"
-      [amount]="'5000000'" [ref]="tRef"
-      (close)="paymentCancel()"
+      [amount]="'5000000'"
+      [ref]="tRef"
+      (onClose)="paymentCancel()"
       (callback)="paymentDone($event)"
       [class]="'btn btn-primary'"
     >
@@ -18,29 +23,37 @@
       class="btn btn-danger m-3"
       angular4-paystack
       [paystackOptions]="options"
-      (close)="paymentCancel()"
-      (paymentInit)="paymentInit()"      
+      (onClose)="paymentCancel()"
+      (paymentInit)="paymentInit()"
       (callback)="paymentDone($event)"
       [class]="'btn btn-primary btn-lg'"
     >
       Pay With Paystack Directive
     </button>
   </div>
-  <button class="btn btn-outline-dark mr-3" (click)="toggleEmbed()">Toggle embed</button>
-  <button class="btn btn-outline-dark" (click)="setRandomPaymentRef()">Set random payment Ref</button>
-  <h3>Embed {{ showEmbed ? 'visible' : 'hidden' }}</h3>
+  <button class="btn btn-outline-dark mr-3" (click)="toggleEmbed()">
+    Toggle embed
+  </button>
+  <button class="btn btn-outline-dark" (click)="setRandomPaymentRef()">
+    Set random payment Ref
+  </button>
+  <h3>Embed {{ showEmbed ? "visible" : "hidden" }}</h3>
   <div>
-    You can't have more than one payment Instance at a time. Hide paystack embed to try out
-    paystack directive and paystack component
+    You can't have more than one payment Instance at a time. Hide paystack embed
+    to try out paystack directive and paystack component
   </div>
   <h3 class="text-center my-3">Paystack Embed</h3>
   <div *ngIf="showEmbed">
     <angular4-paystack-embed
       angular4-paystack
       [email]="'mailexample@mail.com'"
-      (paymentInit)="paymentInit()"      
-      [amount]="'5000000'" [ref]="tRef" (close)="paymentCancel()" (callback)="paymentDone($event)"
-      [class]="'btn btn-primary btn-lg'" [channels]="['card']"
+      (paymentInit)="paymentInit()"
+      [amount]="'5000000'"
+      [ref]="tRef"
+      (onClose)="paymentCancel()"
+      (callback)="paymentDone($event)"
+      [class]="'btn btn-primary btn-lg'"
+      [channels]="['card']"
     ></angular4-paystack-embed>
   </div>
 </div>


### PR DESCRIPTION
The close event name is 'onClose' but the code documentation says 'close'. (close) obviously didn't work but (onClose) did.

I fixed this typo in the README.md and included examples.