### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Also you can use the `paystackOptions` object like so:
   <button
     angular4-paystack
     [paystackOptions]="options"
-    (paymentInit)="paymentCancel()"
+    (paymentInit)="paymentInit()"
     (close)="paymentCancel()"
     (callback)="paymentDone($event)"
   >


### PR DESCRIPTION
One of the payment inits options in the example given in readme was pointing to cancel method instead of payment Init method.