### PR TITLE
Fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are two available options
       [ref]="reference"
       [channels]="['bank']"
       [class]="'btn btn-primary'"
-      (close)="paymentCancel()"
+      (onClose)="paymentCancel()"
       (callback)="paymentDone($event)"
     >
       Pay with Paystack
@@ -55,7 +55,7 @@ There are two available options
     [ref]="reference"
     [class]="'btn btn-primary'"
     (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
+    (onClose)="paymentCancel()"
     (callback)="paymentDone($event)"
   >
     Pay with Paystack
@@ -100,7 +100,7 @@ Also you can use the `paystackOptions` object like so:
     angular4-paystack
     [paystackOptions]="options"
     (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
+    (onClose)="paymentCancel()"
     (callback)="paymentDone($event)"
   >
     Pay with Paystack
@@ -157,7 +157,7 @@ and this in your component
     [ref]="reference"
     [class]="'btn btn-primary'"
     (paymentInit)="paymentInit()"
-    (close)="paymentCancel()"
+    (onClose)="paymentCancel()"
     (callback)="paymentDone($event)"
   >
     Pay with Paystack

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
       [email]="'mailexample@mail.com'"
       (paymentInit)="paymentInit()"
       [amount]="'5000000'" [ref]="tRef"
-      (close)="paymentCancel()"
+      (onClose)="paymentCancel()"
       (callback)="paymentDone($event)"
       [class]="'btn btn-primary'"
     >
@@ -18,7 +18,7 @@
       class="btn btn-danger m-3"
       angular4-paystack
       [paystackOptions]="options"
-      (close)="paymentCancel()"
+      (onClose)="paymentCancel()"
       (paymentInit)="paymentInit()"      
       (callback)="paymentDone($event)"
       [class]="'btn btn-primary btn-lg'"
@@ -39,7 +39,7 @@
       angular4-paystack
       [email]="'mailexample@mail.com'"
       (paymentInit)="paymentInit()"      
-      [amount]="'5000000'" [ref]="tRef" (close)="paymentCancel()" (callback)="paymentDone($event)"
+      [amount]="'5000000'" [ref]="tRef" (onClose)="paymentCancel()" (callback)="paymentDone($event)"
       [class]="'btn btn-primary btn-lg'" [channels]="['card']"
     ></angular4-paystack-embed>
   </div>


### PR DESCRIPTION
There was an error on the README markdown file, which I corrected.
'close' was used instead of 'onClose' in the doc. 