### PR TITLE
Fix broken link to Paystack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Then `pk_test_2` would be used instead
 |  `bearer`             | `string`       | false               |  ""                 | Who bears Paystack charges? account or subaccount
 |  `channels`           | `array`         | false              | undefined  | Send 'card' or 'bank' or 'card','bank' as an array to specify what options to show the user paying
 
-> For more information checkout [paystack's documentation](https://developers.paystack.co/docs/paystack-inline#section-working-with-paystack-inline)
+> For more information checkout [paystack's documentation](https://paystack.com/docs/payments/accept-payments/)
 
 ## Contributing
 


### PR DESCRIPTION
Corrected the link that leads to the page on Paystack documentation that contains the table about accepting payments