### PR TITLE
chore: add explicit access modifiers to methods in Angular4PaystackEmbedComponent

### DIFF
--- a/projects/angular4-paystack/src/lib/angular4-paystack-embed.component.ts
+++ b/projects/angular4-paystack/src/lib/angular4-paystack-embed.component.ts
@@ -35,7 +35,7 @@ export class Angular4PaystackEmbedComponent implements OnInit {
 
   constructor(private paystackService: Angular4PaystackService) {}
 
-  async pay() {
+  public async pay() {
     let errorText = '';
     if (this.paystackOptions && Object.keys(this.paystackOptions).length >= 2) {
       errorText = this.valdateInput(this.paystackOptions);
@@ -57,14 +57,14 @@ export class Angular4PaystackEmbedComponent implements OnInit {
     return '';
   }
 
-  valdateInput(obj: PaystackOptions) {
+  private valdateInput(obj: PaystackOptions) {
     if (!this.callback.observers.length) {
       return 'ANGULAR-PAYSTACK: Insert a callback output like so (callback)=\'PaymentComplete($event)\' to check payment status';
     }
     return this.paystackService.checkInput(obj);
   }
 
-  generateOptions(obj: PaystackOptions) {
+  private generateOptions(obj: PaystackOptions) {
     this._paystackOptions = this.paystackService.getPaystackOptions(obj);
     this._paystackOptions.onClose = () => {
       if (this.onClose.observers.length) {
@@ -76,7 +76,7 @@ export class Angular4PaystackEmbedComponent implements OnInit {
     };
   }
 
-  async ngOnInit() {
+  public async ngOnInit() {
     console.error(
       'ANGULAR-PAYSTACK: The paystack embed option is deprecated. Please use the paystack component or directive'
     );


### PR DESCRIPTION
This PR refactors the [Angular4PaystackEmbedComponent] by adding explicit TypeScript access modifiers (public and private) to all declared methods. This change improves code clarity, maintainability, and aligns with TypeScript best practices by clearly distinguishing public API methods from internal helpers. No logic or functionality has been altered.

**Why?**
- Enhances readability for contributors and users.
- Prevents accidental usage of internal methods.
- Makes the component’s API surface explicit.
- Non-breaking change: all public methods remain accessible as before.