### PR TITLE
Add Angular 18-21 peer dependency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `angular4-paystack` will be documented in this file
 
+## 3.1.5 - 24-07-26
+### Fixed
+  - Peer dependency update for angular 18, 19, 20 & 21 support
+
 ## 3.1.4 - 18-03-24
 ### Fixed
   - Fixed peer dependencies version issues

--- a/projects/angular4-paystack/CHANGELOG.md
+++ b/projects/angular4-paystack/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `angular4-paystack` will be documented in this file
 
+## 3.1.5 - 24-07-26
+### Fixed
+  - Peer dependency update for angular 18, 19, 20 & 21 support
+
 ## 3.1.4 - 18-03-24
 ### Fixed
   - Fixed peer dependencies version issues

--- a/projects/angular4-paystack/package.json
+++ b/projects/angular4-paystack/package.json
@@ -1,9 +1,9 @@
 {
   "name": "angular4-paystack",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "peerDependencies": {
-    "@angular/common": "8.0.0 - 17.x.x",
-    "@angular/core": "8.0.0 - 17.x.x"
+    "@angular/common": "8.0.0 - 21.x.x",
+    "@angular/core": "8.0.0 - 21.x.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

The library currently caps its Angular peer range at `8.0.0 - 17.x.x`, which blocks consumers running Angular 18, 19, 20 and 21 from installing it (they hit an unmet peer dependency error).

This PR widens the peer range to `8.0.0 - 21.x.x` for both `@angular/common` and `@angular/core`, mirroring the earlier "Peer dependency update for angular 17 support" change (3.1.3).

## Changes
- `projects/angular4-paystack/package.json`: widen `@angular/common` and `@angular/core` peer deps from `8.0.0 - 17.x.x` to `8.0.0 - 21.x.x`, and bump `version` from `3.1.4` to `3.1.5`.
- `CHANGELOG.md`: add a `3.1.5` entry noting Angular 18, 19, 20 & 21 support.

No library source code was changed; this is a peer-range widening only.

## Verification
- `npm install` and `npm run build` run cleanly from the repo root; the `angular4-paystack` package builds successfully.